### PR TITLE
fix: change getStaticPaths' fallback method to 'blocking'

### DIFF
--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -75,7 +75,7 @@ export async function getStaticPaths() {
 
   return {
     paths,
-    fallback: false,
+    fallback: 'blocking',
   };
 }
 


### PR DESCRIPTION
- waits for HTML to be generated for new paths
- completes ISR pattern for dynamic route